### PR TITLE
preparingproject/bugfix/loginnullpointer

### DIFF
--- a/back-end/src/main/java/drafter/security/LoginService.java
+++ b/back-end/src/main/java/drafter/security/LoginService.java
@@ -66,8 +66,7 @@ public class LoginService implements UserDetailsService {
 		//Assert.assertTrue(principal instanceof UserAccount);
 		try {
 		result = findByEmailAndPassword(principal.toString()).getUserAccount();
-		} catch (Exception e){
-			throw new NullPointerException("Error login.");
+		} catch (NullPointerException e){
 		}
 		//Assert.assertNotNull(result);
 		//Assert.assertTrue(result.getId() != 0);

--- a/front-end/package-lock.json
+++ b/front-end/package-lock.json
@@ -7598,7 +7598,7 @@
       "dependencies": {
         "@types/node": {
           "version": "8.9.5",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-8.9.5.tgz",
+          "resolved": "http://registry.npmjs.org/@types/node/-/node-8.9.5.tgz",
           "integrity": "sha512-jRHfWsvyMtXdbhnz5CVHxaBgnV6duZnPlQuRSo/dm/GnmikNcmZhxIES4E9OZjUmQ8C+HCl4KJux+cXN/ErGDQ==",
           "optional": true
         },


### PR DESCRIPTION
La traza de error que imprimia el servidor cada vez que se interactuaba con el valor que arrojaba el getPrincipal(), error NullPointerException, ya no sucede.